### PR TITLE
pin down dependencies for the build to succeed

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,15 +11,15 @@
 
 [common_env_data]
 lib_deps_embedded_external =
-  I2Cdevlib-MPU6050
+  https://github.com/tzapu/WiFiManager#v2.0.15-rc.1
+  jrowberg/I2Cdevlib-MPU6050#c4e96ebba8b6b77d93c478d501c077fd6c0421ad
   Brzo I2C@1.3.2
-  https://github.com/tzapu/WiFiManager
-  ArduinoJson
+  bblanchon/ArduinoJson@6.13.0
   electroniccats/MPU6050@^0.5.0
 
 
 [env:wemos]
-platform = espressif8266
+platform = espressif8266@4.1.0
 framework = arduino
 board = esp01_1m
 #upload_resetmethod = nodemcu


### PR DESCRIPTION
Pinned down older versions or commits of related libraries for the build to succeed. This worked for me, runs MPU6050 on Wemos D1 mini (had to adjust code so it uses 6050 instead of 9250).